### PR TITLE
Guide EN & FR: (Prompting) - New titles for section

### DIFF
--- a/guide_en.md
+++ b/guide_en.md
@@ -422,7 +422,8 @@ To sum up:
 | **Tutorial**     | Structure, simplify    | Proofreading, visuals     | Adapt to context |
 
 
-# Prompting like a pro
+# Ask Smart, Get More: Techniques for Guiding AI 
+
 
 # Wrap-up
 

--- a/guide_fr.md
+++ b/guide_fr.md
@@ -426,8 +426,7 @@ En résumé :
 | **Tutoriel**      | Structurer, simplifier    | Relecture, visuels            | Adapter au contexte |
 
 
-
-# 'Prompter' comme un prompter
+# Bien demander, mieux générer : Techniques pour guider l’IA
 
 ***Par Antoni Bourdel***
 


### PR DESCRIPTION
In addition to the ones in the file, two other alternative options :

 **« Guider l’IA : Préparer, Formuler, Affiner »**
 **" Guiding AI: Prepare, Design, Refine"**
-> Sums-up the 3 points of this text

**« La recette des bonnes réponses : Ingrédients et étapes »**
**"Recipe for the right generations: Ingredients and steps"**
-> Builds upon existing comparisons with cooking in this text (and often used elsewhere for AI, "let it cook"). Used "generation" in English, because I think it's more intuitively tied to AI, but "answers" seems good too. 

 **(Current pick) « Bien demander, mieux générer : Techniques pour guider l’IA »**
**"Ask Smart, Get More: Techniques for Guiding AI "**
-> Easy to understand and looks nice?

I excluded the word "prompt" since it's defined in the text later, it seemed more accessible without. 

@qaco @ttourmaline 