### PR TITLE
Guide EN & FR: (Start/Walkthrough) Remove French typo and confusing advice

### DIFF
--- a/guide_en.md
+++ b/guide_en.md
@@ -75,8 +75,8 @@ After receiving a response, you can react to its content by replying -- it’s a
 #### A Few Tips:
 
 - **Be specific:** The clearer your request, the better the response.
-- **Always proofread:** AI can make mistakes or overlook nuances. Correct, supplement, and adapt as needed.
-- **Don’t share sensitive information:** Avoid names, addresses, or personal data.
+- **Always proofread:** AI can make mistakes or overlook nuances. Correct, supplement, and adapt as needed its generations.
+- **Don’t share sensitive information:** Avoid names, addresses, or personal data in your messages.
 
 
 #### Example Exchange:
@@ -130,8 +130,6 @@ These are found in the left column of Mistral’s interface.
 - **Intelligence** : Feed the AI persistent data, whether memories, personal information, connectors to other platforms (like Gmail for emails), or document libraries, so that the results benefit from this additional information.
 
 *For example, you can request a critical and synthetic analysis of the latest government speeches on pension reform, with key arguments to fuel a public debate or a press release.*
-
-It may be tempting to share sensitive personal information: If you choose to do so, select it carefully.
 
 As with AI in general, these advanced options are not yet capable of meeting all demands and may yield unsatisfactory results. Again, try to see how these tools, in their current state, can help you work faster -- without expecting them to do everything for you.
 

--- a/guide_fr.md
+++ b/guide_fr.md
@@ -77,8 +77,8 @@ Après avoir obtenu une réponse, vous pouvez réagir sur son contenu en répond
 #### Quelques conseils :
 
 - **Soyez concret** : plus votre demande est précise, meilleure sera la réponse.
-- **Relisez toujours** : l’IA peut faire des erreurs ou oublier des nuances. Corrigiez, complétez, adaptez.
-- **Ne partagez pas d’infos sensibles** : évitez les noms, adresses, ou données personnelles.
+- **Relisez toujours** : l’IA peut faire des erreurs ou oublier des nuances. Corrigez, complétez, adaptez sa réponse.
+- **Ne partagez pas d’infos sensibles** : évitez les noms, adresses, ou données personnelles dans vos messages.
 
 #### Exemple d’échange :
 
@@ -130,8 +130,6 @@ Celles-ci se trouvent dans la colonne de gauche de l'interface de Mistral.
 - **Intelligence** : Alimente l'IA de données persistantes, que ce soit des souvenirs, des informations personnelles, des connecteurs vers d'autres plateformes (comme Gmail pour mes mails) ou des bibliothèses de documents, de manière à ce que le résultat bénéficie de ces informations supplémentaires.
 
 *Par exemple, il est possible de demander une analyse critique et synthétique des derniers discours gouvernementaux sur la réforme des retraites, avec des arguments clés pour alimenter un débat public ou un communiqué.*
-
-Il peut être tentant de transmettre des informations personnelles sensibles : si vous tenez à le faire, veillez à les sélectionner scrupuleusement.
 
 Comme pour l'IA en général, ces options avancées ne sont pas encore en capacité de répondre à toutes les demandes, et peuvent fournir des résultats insatisfaisants. Cette fois encore, essayez de voir de quelle manière ces outils, à leur état actuel d'avancement, peuvent vous aider à aller plus vite -- sans vous attendre à ce qu'ils fassent tout à votre place !
 


### PR DESCRIPTION
A typo in French ("corrigiez"). And I added some words to differentiate advice related to user prompts /VS/ AI generations. 

I also suggest we remove this sentence (in both languages) :  
"Il peut être tentant de transmettre des informations personnelles sensibles : si vous tenez à le faire, veillez à les sélectionner scrupuleusement." / "It may be tempting to share sensitive personal information: If you choose to do so, select it carefully."
-> There's an other advice on this just a bit earlier in the text, that advise to not use information that identify people, maybe it's confusing to add this as well ?